### PR TITLE
Add support for board sizes up to 50x50

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -14,7 +14,7 @@ Comment out the exec svnversion for releases.
 <!--
 <exec executable="svnversion" outputproperty="svnversion"/>
 -->
-<property name="version" value="0.9.1"/>
+<property name="version" value="0.9.2"/>
 
 <tstamp><format property="DSTAMP" pattern="yyyy-MM-dd" timezone="UCT"/>
 <format property="TSTAMP" pattern="hh:mm" timezone="UCT"/></tstamp>

--- a/src/hexgui/gui/BoardDrawerDiamond.java
+++ b/src/hexgui/gui/BoardDrawerDiamond.java
@@ -120,7 +120,7 @@ public class BoardDrawerDiamond extends BoardDrawerBase
 	xoffset = 0;
 	for (int x=0; x<m_bwidth; x++) {
 	    if (alphatop)
-		string = Character.toString((char)((int)'A' + x));
+		string = Character.toString(HexPoint.X_COORDINATES[x]);
 	    else
 		string = Integer.toString(x+1);
 	    drawLabel(g, getLocation(x, -1), string, xoffset);
@@ -129,7 +129,7 @@ public class BoardDrawerDiamond extends BoardDrawerBase
 	xoffset = 0;	
 	for (int y=0; y<m_bheight; y++) {
 	    if (!alphatop)
-		string = Character.toString((char)((int)'A' + y));
+		string = Character.toString(HexPoint.X_COORDINATES[y]);
 	    else
 		string = Integer.toString(y+1);
 	    drawLabel(g, getLocation(-1, y), string, xoffset);

--- a/src/hexgui/gui/BoardDrawerDiamond.java
+++ b/src/hexgui/gui/BoardDrawerDiamond.java
@@ -120,7 +120,7 @@ public class BoardDrawerDiamond extends BoardDrawerBase
 	xoffset = 0;
 	for (int x=0; x<m_bwidth; x++) {
 	    if (alphatop)
-		string = Character.toString(HexPoint.X_COORDINATES[x]);
+		string = "" + HexPoint.printableXCoordinate(HexPoint.X_COORDINATES[x]);
 	    else
 		string = Integer.toString(x+1);
 	    drawLabel(g, getLocation(x, -1), string, xoffset);
@@ -129,7 +129,7 @@ public class BoardDrawerDiamond extends BoardDrawerBase
 	xoffset = 0;	
 	for (int y=0; y<m_bheight; y++) {
 	    if (!alphatop)
-		string = Character.toString(HexPoint.X_COORDINATES[y]);
+		string = "" + HexPoint.printableXCoordinate(HexPoint.X_COORDINATES[y]);
 	    else
 		string = Integer.toString(y+1);
 	    drawLabel(g, getLocation(-1, y), string, xoffset);

--- a/src/hexgui/gui/BoardDrawerFlat.java
+++ b/src/hexgui/gui/BoardDrawerFlat.java
@@ -106,7 +106,7 @@ public class BoardDrawerFlat extends BoardDrawerBase
 	yoffset = 1;
 	for (int x=0; x<m_bwidth; x++) {
 	    if (alphatop)
-		string = Character.toString((char)((int)'A' + x));
+		string = Character.toString(HexPoint.X_COORDINATES[x]);
 	    else
 		string = Integer.toString(x+1);
 	    drawLabel(g, getLocation(x, -1), string, xoffset);
@@ -116,7 +116,7 @@ public class BoardDrawerFlat extends BoardDrawerBase
 	yoffset = 0;
 	for (int y=0; y<m_bheight; y++) {
 	    if (!alphatop)
-		string = Character.toString((char)((int)'A' + y));
+		string = Character.toString(HexPoint.X_COORDINATES[y]);
 	    else
 		string = Integer.toString(y+1);
 	    drawLabel(g, getLocation(-1, y), string, xoffset);

--- a/src/hexgui/gui/BoardDrawerFlat.java
+++ b/src/hexgui/gui/BoardDrawerFlat.java
@@ -106,7 +106,7 @@ public class BoardDrawerFlat extends BoardDrawerBase
 	yoffset = 1;
 	for (int x=0; x<m_bwidth; x++) {
 	    if (alphatop)
-		string = Character.toString(HexPoint.X_COORDINATES[x]);
+			string = "" + HexPoint.printableXCoordinate(HexPoint.X_COORDINATES[x]);
 	    else
 		string = Integer.toString(x+1);
 	    drawLabel(g, getLocation(x, -1), string, xoffset);
@@ -116,7 +116,7 @@ public class BoardDrawerFlat extends BoardDrawerBase
 	yoffset = 0;
 	for (int y=0; y<m_bheight; y++) {
 	    if (!alphatop)
-		string = Character.toString(HexPoint.X_COORDINATES[y]);
+		string = "" + HexPoint.printableXCoordinate(HexPoint.X_COORDINATES[y]);
 	    else
 		string = Integer.toString(y+1);
 	    drawLabel(g, getLocation(-1, y), string, xoffset);

--- a/src/hexgui/gui/BoardDrawerGo.java
+++ b/src/hexgui/gui/BoardDrawerGo.java
@@ -132,7 +132,7 @@ public class BoardDrawerGo extends BoardDrawerBase
 	xoffset = yoffset = 0;
 	for (int x=0; x<m_bwidth; x++) {
 	    if (alphatop)
-		string = Character.toString(HexPoint.X_COORDINATES[x]);
+		string = "" + HexPoint.printableXCoordinate(HexPoint.X_COORDINATES[x]);
 	    else
 		string = Integer.toString(x+1);
 	    drawLabel(g, getLocation(x, -1), string, xoffset);
@@ -141,7 +141,7 @@ public class BoardDrawerGo extends BoardDrawerBase
 	xoffset = yoffset = 0;
 	for (int y=0; y<m_bheight; y++) {
 	    if (!alphatop)
-		string = Character.toString(HexPoint.X_COORDINATES[y]);
+		string = "" + HexPoint.printableXCoordinate(HexPoint.X_COORDINATES[y]);
 	    else
 		string = Integer.toString(y+1);
 	    drawLabel(g, getLocation(-1, y), string, xoffset);

--- a/src/hexgui/gui/BoardDrawerGo.java
+++ b/src/hexgui/gui/BoardDrawerGo.java
@@ -132,7 +132,7 @@ public class BoardDrawerGo extends BoardDrawerBase
 	xoffset = yoffset = 0;
 	for (int x=0; x<m_bwidth; x++) {
 	    if (alphatop)
-		string = Character.toString((char)((int)'A' + x));
+		string = Character.toString(HexPoint.X_COORDINATES[x]);
 	    else
 		string = Integer.toString(x+1);
 	    drawLabel(g, getLocation(x, -1), string, xoffset);
@@ -141,7 +141,7 @@ public class BoardDrawerGo extends BoardDrawerBase
 	xoffset = yoffset = 0;
 	for (int y=0; y<m_bheight; y++) {
 	    if (!alphatop)
-		string = Character.toString((char)((int)'A' + y));
+		string = Character.toString(HexPoint.X_COORDINATES[y]);
 	    else
 		string = Integer.toString(y+1);
 	    drawLabel(g, getLocation(-1, y), string, xoffset);

--- a/src/hexgui/gui/BoardDrawerY.java
+++ b/src/hexgui/gui/BoardDrawerY.java
@@ -103,7 +103,7 @@ public class BoardDrawerY extends BoardDrawerBase
 	xoffset = m_fieldWidth/2;
 	yoffset = 1;
 	for (int x=0; x<m_bwidth; x++) {
-            string = Character.toString(HexPoint.X_COORDINATES[x]);
+            string = "" + HexPoint.printableXCoordinate(HexPoint.X_COORDINATES[x]);
 	    //drawLabel(g, getLocation(x, -1), string, xoffset);
 	    drawLabel(g, getLocation(x, m_bheight), string, xoffset);
 	}

--- a/src/hexgui/gui/BoardDrawerY.java
+++ b/src/hexgui/gui/BoardDrawerY.java
@@ -103,7 +103,7 @@ public class BoardDrawerY extends BoardDrawerBase
 	xoffset = m_fieldWidth/2;
 	yoffset = 1;
 	for (int x=0; x<m_bwidth; x++) {
-            string = Character.toString((char)((int)'A' + x));
+            string = Character.toString(HexPoint.X_COORDINATES[x]);
 	    //drawLabel(g, getLocation(x, -1), string, xoffset);
 	    drawLabel(g, getLocation(x, m_bheight), string, xoffset);
 	}

--- a/src/hexgui/gui/HexGui.java
+++ b/src/hexgui/gui/HexGui.java
@@ -1766,7 +1766,7 @@ public final class HexGui
             {
                 if (m_guiboard.getColor(move.getPoint()) !=  HexColor.EMPTY)
                 {
-                    ShowError.msg(this, "Cell '" + move.getPoint().toString() +
+                    ShowError.msg(this, "Cell '" + move.getPoint().toDisplayString() +
                                   "' already occupied.");
                     return;
                 }
@@ -1796,8 +1796,8 @@ public final class HexGui
 	m_toolbar.updateButtonStates(m_current);
         m_menubar.updateMenuStates(m_current);
         m_statusbar.setMessage(m_current.getDepth() + " " 
-                               + move.getColor().toString() + " " 
-                               + move.getPoint().toString());
+                               + move.getColor().toString() + " "
+                               + move.getPoint().toDisplayString());
         setComment(m_current);
 
 	setGameChanged(true);
@@ -1837,7 +1837,7 @@ public final class HexGui
         htpPlay(move);
 
         m_statusbar.setMessage("Added setup stone (" + move.getColor().toString() +
-                               ", " + move.getPoint().toString() + ")");
+                               ", " + move.getPoint().toDisplayString() + ")");
 
         setGameChanged(true);
         setFrameTitle();
@@ -1910,7 +1910,7 @@ public final class HexGui
             {
                 m_statusbar.setMessage(node.getDepth() + " "
                                        + move.getColor().toString() + " "
-                                       + move.getPoint().toString());
+                                       + move.getPoint().toDisplayString());
             }
         }
         if (node.hasSetup())
@@ -1950,7 +1950,7 @@ public final class HexGui
             Move move = m_current.getMove();
             m_statusbar.setMessage(m_current.getDepth() + " " 
                                    + move.getColor().toString() + " " 
-                                   + move.getPoint().toString());
+                                   + move.getPoint().toDisplayString());
         }
         if (m_current.hasLabel())
             displayLabels(m_current);

--- a/src/hexgui/hex/HexPoint.java
+++ b/src/hexgui/hex/HexPoint.java
@@ -103,7 +103,7 @@ public final class HexPoint implements Comparable
             return SWAP_PIECES;
 
         for (int x=0; x<MAX_POINTS; x++) 
-            if (name.equalsIgnoreCase(s_points[x].toString()))
+            if (name.equals(s_points[x].toString()))
                 return s_points[x];
         assert(false);
 	return null;

--- a/src/hexgui/hex/HexPoint.java
+++ b/src/hexgui/hex/HexPoint.java
@@ -28,16 +28,16 @@ public final class HexPoint implements Comparable
     public static final HexPoint RESIGN;
     public static final HexPoint INVALID;
 
-    public static final int MAX_WIDTH  = 40;
-    public static final int MAX_HEIGHT = 40;
+    public static final int MAX_WIDTH  = 50;
+    public static final int MAX_HEIGHT = 50;
     public static final int MAX_POINTS = MAX_WIDTH*MAX_HEIGHT + 7;
 
     public static final int DEFAULT_SIZE = 11;
 
     private static HexPoint s_points[];
     public static final char[] X_COORDINATES = new char[] {
-	        'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
-            'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z'
+	        'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+            'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z'
     };
 
     static 
@@ -59,6 +59,19 @@ public final class HexPoint implements Comparable
 		s_points[7 + y*MAX_WIDTH+ x] = new HexPoint(x, y, name);
 	    }
 	}
+    }
+
+    public static char printableXCoordinate(char c) {
+        int x = 0;
+        while (HexPoint.X_COORDINATES[x] != c) x++;
+
+        if (x < 8) {
+            return c;
+        } else if (x < 33) {
+            return HexPoint.X_COORDINATES[x + 1];
+        } else {
+            return HexPoint.X_COORDINATES[x + 2];
+        }
     }
 
     /** Returns the point with the given index.
@@ -113,6 +126,16 @@ public final class HexPoint implements Comparable
     public String toString()
     {
 	return m_string;
+    }
+
+    /** Returns the human-readable representation of the point (with i and I x-coordinates removed for clarity). */
+    public String toDisplayString() {
+        for (int i = 0; i < 7; i++) {
+            if (s_points[i].toString() == m_string) {
+                return m_string;
+            }
+        }
+        return printableXCoordinate(m_string.charAt(0)) + m_string.substring(1);
     }
 
     /** Convert a list of points to a string.

--- a/src/hexgui/hex/HexPoint.java
+++ b/src/hexgui/hex/HexPoint.java
@@ -28,19 +28,23 @@ public final class HexPoint implements Comparable
     public static final HexPoint RESIGN;
     public static final HexPoint INVALID;
 
-    public static final int MAX_WIDTH  = 19;
-    public static final int MAX_HEIGHT = 19;
+    public static final int MAX_WIDTH  = 40;
+    public static final int MAX_HEIGHT = 40;
     public static final int MAX_POINTS = MAX_WIDTH*MAX_HEIGHT + 7;
 
     public static final int DEFAULT_SIZE = 11;
 
     private static HexPoint s_points[];
+    public static final char[] X_COORDINATES = new char[] {
+	        'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+            'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z'
+    };
 
     static 
     {
 	s_points = new HexPoint[MAX_POINTS];
 
-        INVALID     = s_points[0] = new HexPoint(0, "invalid");
+    INVALID     = s_points[0] = new HexPoint(0, "invalid");
 	RESIGN      = s_points[1] = new HexPoint(1, "resign");
 	SWAP_PIECES = s_points[2] = new HexPoint(2, "swap-pieces");
 
@@ -51,7 +55,7 @@ public final class HexPoint implements Comparable
 
 	for (int y=0; y<MAX_HEIGHT; y++) {
 	    for (int x=0; x<MAX_WIDTH; x++) {
-		String name = "" + (char)('a' + x) + (y+1);
+		String name = "" + X_COORDINATES[x] + (y+1);
 		s_points[7 + y*MAX_WIDTH+ x] = new HexPoint(x, y, name);
 	    }
 	}

--- a/src/hexgui/sgf/SgfReader.java
+++ b/src/hexgui/sgf/SgfReader.java
@@ -192,7 +192,7 @@ public final class SgfReader
 
     private HexPoint parseMove(String s) throws SgfError
     {
-        s = s.trim().toLowerCase(Locale.ENGLISH);
+        s = s.trim();
         // HexPoint.get() handles special move values like "swap"
         HexPoint result = HexPoint.get(s);
         if (result == null)


### PR DESCRIPTION
The coordinate system uses lower-case a-z for x-coordinates between 1 and 25, and upper-case A-Z for x-coordinates between 26-50, in both cases leaving out i/I because of the ambiguity with l.

This allows for boards up to 50x50 to be displayed. SGFs should be completely backwards-compatible.